### PR TITLE
Fix notice when there's an exception thrown from the update callback

### DIFF
--- a/tlc-transients.php
+++ b/tlc-transients.php
@@ -78,7 +78,9 @@ if ( !class_exists( 'TLC_Transient' ) ) {
 			try {
  				$data = call_user_func_array( $this->callback, $this->params );
 				$this->set( $data );
-			} catch( Exception $e ) {}
+			} catch( Exception $e ) {
+				$data = false;
+			}
 			$this->release_update_lock();
 			return $data;
 		}


### PR DESCRIPTION
If the update callback throws an exception then fetch_and_cache() tries to return $data which isn't set. This avoids the notice

Looks like I made it through an upstream rebase :-)
