### PR TITLE
Addition of prevent_background option

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,15 @@ echo tlc_transient( 'example-feed' )
 	->get();
 ?>
 ```
+In some exceptional cases you may not want background updates.  This is less efficient and almost negates the need for use of this library, but it allows calling code to easily choose between using background updates or not without having to rewrite their whole transient-handling code.
+
+```php
+// Grab that feed - don't background-update
+echo tlc_transient( 'example-feed' )
+	->updates_with( 'my_callback_with_param', array( 'bar' ) )
+	->prevent_background()
+	->expires_in( 300 )
+	->background_only()
+	->get();
+?>
+```

--- a/tlc-transients.php
+++ b/tlc-transients.php
@@ -30,6 +30,7 @@ if ( !class_exists( 'TLC_Transient' ) ) {
 		private $params;
 		private $expiration = 0;
 		private $force_background_updates = false;
+		private $prevent_background_updates = false;
 
 		public function __construct( $key ) {
 			$this->key = substr( $key, 0, 37 );
@@ -50,8 +51,13 @@ if ( !class_exists( 'TLC_Transient' ) ) {
 				}
 			} else {
 				// Soft expiration
-				if ( $data[0] !== 0 && $data[0] < time() )
-					$this->schedule_background_fetch();
+				if ( $data[0] !== 0 && $data[0] < time() ) {
+					if ( $this->prevent_background_updates ) {
+						return $this->fetch_and_cache();
+					} else {
+						$this->schedule_background_fetch();
+					}
+				}
 				return $data[1];
 			}
 		}
@@ -137,6 +143,11 @@ if ( !class_exists( 'TLC_Transient' ) ) {
 
 		public function background_only() {
 			$this->force_background_updates = true;
+			return $this;
+		}
+
+		public function prevent_background() {
+			$this->prevent_background_updates = true;
 			return $this;
 		}
 	}


### PR DESCRIPTION
Hi Mark,

I've never contributed to an open source project before, so I'm starting small.

You may not want to adopt this little change/addition because using the new option wipes out most of the benefits of using TLC Transients in one fell swoop, but let me explain.

It turns out that there are some hosts out there that don't allow "loopback" HTTP requests. So the server running on http://my-domain.com can't make an HTTP request to http://my-domain.com

This has, I have found, at least two symptoms:
1) wp-cron doesn't work
2) TLC Transients doesn't work

I found this out through Twitter Widget Pro not updating correctly.  A write up is here: http://oikos.org.uk/2012/03/tech-notes-twitter-widget-pro-not-updating-for-heart-internet-users/

I initially suggested to the author of Twitter Widget Pro that he make use of TLC Transients optional in his plugin, but that would mean reworking all of his transient handling code.  Easier, I thought, to add a "suppress background requests" option to TLC Transients.

So that's what I've done.

Like I say, I don't mind if you don't adopt the change, but I've done the work so I thought I'd at least submit it to you for review.

As I say I've never contributed to someone else's code before so I've hope I've done it all right with the GIT Pull Request and so on.

Thanks!

Ross Wintle
