### PR TITLE
Default expiry, notice/warning prevention, key collision bug fix

### DIFF
--- a/tlc-transients.php
+++ b/tlc-transients.php
@@ -1,4 +1,7 @@
 <?php
+if ( ! defined( 'TLC_TRANSIENT_TTL_DEFAULT' ) ) {
+	define( 'TLC_TRANSIENT_TTL_DEFAULT', 300 );
+}
 
 if ( !class_exists( 'TLC_Transient_Update_Server' ) ) {
 	class TLC_Transient_Update_Server {
@@ -30,7 +33,7 @@ if ( !class_exists( 'TLC_Transient' ) ) {
 		private $lock;
 		private $callback;
 		private $params;
-		private $expiration = 0;
+		private $expiration = TLC_TRANSIENT_TTL_DEFAULT;
 		private $force_background_updates = false;
 
 		public function __construct( $key ) {
@@ -60,7 +63,7 @@ if ( !class_exists( 'TLC_Transient' ) ) {
 
 		private function schedule_background_fetch() {
 			if ( !$this->has_update_lock() ) {
-				set_transient( 'tlc_up__' . $this->key, array( $this->new_update_lock(), $this->key, $this->expiration, $this->callback, $this->params ), 300 );
+				set_transient( 'tlc_up__' . $this->key, array( $this->new_update_lock(), $this->key, $this->expiration, $this->callback, $this->params ), ( $this->expiration + TLC_TRANSIENT_TTL_DEFAULT ) );
 				add_action( 'shutdown', array( $this, 'spawn_server' ) );
 			}
 			return $this;
@@ -90,8 +93,8 @@ if ( !class_exists( 'TLC_Transient' ) ) {
 		public function set( $data ) {
 			// We set the timeout as part of the transient data.
 			// The actual transient has no TTL. This allows for soft expiration.
-			$expiration = ( $this->expiration > 0 ) ? time() + $this->expiration : 0;
-			set_transient( $this->key, array( $expiration, $data ) );
+			$expiration = ( $this->expiration > 0 ) ? time() + $this->expiration : TLC_TRANSIENT_TTL_DEFAULT;
+			set_transient( $this->key, array( $expiration, $data ), $expiration );
 			return $this;
 		}
 

--- a/tlc-transients.php
+++ b/tlc-transients.php
@@ -10,7 +10,10 @@ if ( !class_exists( 'TLC_Transient_Update_Server' ) ) {
 		}
 	
 		public function init() {
-			if ( isset( $_POST['_tlc_update'] ) ) {
+			if ( isset( $_POST['_tlc_update'] ) 
+				&& ( 0 === strpos( $_POST['_tlc_update'], 'tlc_lock_' ) ) 
+				&& isset( $_POST['key'] ) 
+			) {
 				$update = get_transient( 'tlc_up__' . $_POST['key'] );
 				if ( $update && $update[0] == $_POST['_tlc_update'] ) {
 					tlc_transient( $update[1] )

--- a/tlc-transients.php
+++ b/tlc-transients.php
@@ -103,7 +103,7 @@ if ( !class_exists( 'TLC_Transient' ) ) {
 		}
 
 		private function new_update_lock() {
-			$this->lock = md5( uniqid( microtime() . mt_rand(), true ) );
+			$this->lock = uniqid( 'tlc_lock_', true );
 			return $this->lock;
 		}
 


### PR DESCRIPTION
Hey Mark,

Awesome plugin.  We've started using this class on our WordPress VIP-hosted sites to take the place of a similar method that used a custom database table, and it's working like a charm.  During testing we made some changes that I'd like to share:
- Simplifying the update lock generation
- Changing default transient expiry to 5 minutes. This solves an issue where sites using the default transient system (e.g., `$_wp_using_ext_object_cache == false`) would set an instantly-expiring transient, and thus `tlc_transient()` would never cache.
- Introducing `TLC_TRANSIENT_TTL_DEFAULT` constant (defaults to 5 minutes). Setting transient expiry to `$expiration + TLC_TRANSIENT_TTL_DEFAULT` to give the transient a grace period, so that the transient doesn't expire before its stored TTL.
- Ensuring all expected `$_POST` data is present before trying to interact with it.
- Hashing the transient key to prevent key collisions when long keys are used. Since we're using an MD5 hash for the key, we know the POSTed "key" value in `TLC_Transient_Update_Server::init()` will be 32 characters long, so this lets us do additional validation to make sure we're getting a valid request before trying to cache it.

More changes to `TLC_Transient_Update_Server::init()` -- 
- checking `( isset( $update[0] ) )` instead of just `( $update )` to verify that `$update != false` and `is_array($update)` at the same time, before trying to interact with it. 
- verifying the information stored in the array is what's expected. 
- calling `tlc_transient( $key, 'nohash' )` when setting the transient data to prevent double-hashing the key.
