### PR TITLE
autoload should be 'no'

### DIFF
--- a/tlc-transients.php
+++ b/tlc-transients.php
@@ -94,9 +94,9 @@ if ( !class_exists( 'TLC_Transient' ) ) {
 
 		public function set( $data ) {
 			// We set the timeout as part of the transient data.
-			// The actual transient has no TTL. This allows for soft expiration.
+			// The actual transient has a far-future TTL. This allows for soft expiration.
 			$expiration = ( $this->expiration > 0 ) ? time() + $this->expiration : 0;
-			set_transient( 'tlc__' . $this->key, array( $expiration, $data ) );
+			set_transient( 'tlc__' . $this->key, array( $expiration, $data ), 31536000 ); // 60*60*24*365 ~= one year
 			return $this;
 		}
 

--- a/tlc-transients.php
+++ b/tlc-transients.php
@@ -96,7 +96,7 @@ if ( !class_exists( 'TLC_Transient' ) ) {
 			// We set the timeout as part of the transient data.
 			// The actual transient has a far-future TTL. This allows for soft expiration.
 			$expiration = ( $this->expiration > 0 ) ? time() + $this->expiration : 0;
-			set_transient( 'tlc__' . $this->key, array( $expiration, $data ), 31536000 ); // 60*60*24*365 ~= one year
+			set_transient( 'tlc__' . $this->key, array( $expiration, $data ), $expiration + 31536000 ); // 60*60*24*365 ~= one year
 			return $this;
 		}
 


### PR DESCRIPTION
The transients are stored in wp_options with autoload='yes'. This means if you're storing a lot of different TLC transients with a lot of data (e.g. fetching and caching many URLs), Wordpress will take long to load all the options with autoload='yes' (including the transients), which can cause performance issues.

I think it would be better to store the transients with autoload='no'. Unfortunately, I didn't see a quick fix, because the WordPress transients API only sets autoload when an explicit expiration is set.
