### PR TITLE
Addition of delete() to allow explicit expiry of a transient

### DIFF
--- a/tlc-transients.php
+++ b/tlc-transients.php
@@ -79,7 +79,7 @@ if ( !class_exists( 'TLC_Transient' ) ) {
 
 		public function spawn_server() {
 			$server_url = home_url( '/?tlc_transients_request' );
-			wp_remote_post( $server_url, array( 'body' => array( '_tlc_update' => $this->lock, 'key' => $this->raw_key ), 'timeout' => 0.01, 'blocking' => false, 'sslverify' => apply_filters( 'https_local_ssl_verify', true ) ) );
+			wp_remote_post( $server_url, array( 'body' => array( '_tlc_update' => $this->lock, 'key' => $this->raw_key ), 'timeout' => 5, 'blocking' => false, 'sslverify' => apply_filters( 'https_local_ssl_verify', true ) ) );
 		}
 
 		public function fetch_and_cache() {

--- a/tlc-transients.php
+++ b/tlc-transients.php
@@ -84,7 +84,7 @@ if ( !class_exists( 'TLC_Transient' ) ) {
 
 		public function fetch_and_cache() {
 			// If you don't supply a callback, we can't update it for you!
-			if ( empty( $this->callback ) )
+			if ( empty( $this->callback ) || ! is_callable( $this->callback ) )
 				return false;
 			if ( $this->has_update_lock() && !$this->owns_update_lock() )
 				return; // Race... let the other process handle it

--- a/tlc-transients.php
+++ b/tlc-transients.php
@@ -118,6 +118,11 @@ if ( !class_exists( 'TLC_Transient' ) ) {
 			return $this;
 		}
 
+		public function delete() {
+			delete_transient( 'tlc__' . $this->key );
+			return $this;
+		}
+
 		public function updates_with( $callback, $params = array() ) {
 			$this->callback = $callback;
 			if ( is_array( $params ) )


### PR DESCRIPTION
Having a delete() function allows one to hard expire a transient at any point in code execution, cleaner than setting the expiry to 0 seconds.
