### PR TITLE
Hook TLC_Transient_Update_Server::init at a higher priority.

### DIFF
--- a/tlc-transients.php
+++ b/tlc-transients.php
@@ -3,7 +3,7 @@
 if ( !class_exists( 'TLC_Transient_Update_Server' ) ) {
 	class TLC_Transient_Update_Server {
 		public function __construct() {
-			add_action( 'init', array( $this, 'init' ) );
+			add_action( 'init', array( $this, 'init' ), 9999 );
 		}
 
 		public function init() {


### PR DESCRIPTION
Helps ensure that custom post types and taxonomies have a chance to be registered.
Props to @danielbachhuber for discovering this.

[Co-Authors-Plus](https://github.com/Automattic/Co-Authors-Plus/) users should be aware that that corrupt/inconsistent cached authors are likely to occur without this change.
