### PR TITLE
Fix compatibility with background updates and memcache based object cache

### DIFF
--- a/class-tlc-transient.php
+++ b/class-tlc-transient.php
@@ -103,7 +103,7 @@ class TLC_Transient {
 		// We set the timeout as part of the transient data.
 		// The actual transient has a far-future TTL. This allows for soft expiration.
 		$expiration           = ( $this->expiration > 0 ) ? time() + $this->expiration : 0;
-		$transient_expiration = ( $this->expiration > 0 ) ? $this->expiration + 31536000 : 0; // 31536000 = 60*60*24*365 ~= one year
+		$transient_expiration = ( $this->expiration > 0 ) ? 2592000 : 0; // 2592000 = 60*60*24*30 ~= one month for compatiblity with memcache
 		set_transient( 'tlc__' . $this->key, array( $expiration, $data ), $transient_expiration );
 		return $this;
 	}

--- a/class-tlc-transient.php
+++ b/class-tlc-transient.php
@@ -103,7 +103,7 @@ class TLC_Transient {
 		// We set the timeout as part of the transient data.
 		// The actual transient has a far-future TTL. This allows for soft expiration.
 		$expiration           = ( $this->expiration > 0 ) ? time() + $this->expiration : 0;
-		$transient_expiration = ( $this->expiration > 0 ) ? 2592000 : 0; // 2592000 = 60*60*24*30 ~= one month for compatiblity with memcache
+		$transient_expiration = ( $this->expiration > 0 ) ? apply_filters( 'tlc_transient_ttl', 2592000 ) : 0; // 2592000 = 60*60*24*30 ~= one month for compatiblity with memcache
 		set_transient( 'tlc__' . $this->key, array( $expiration, $data ), $transient_expiration );
 		return $this;
 	}

--- a/class-tlc-transient.php
+++ b/class-tlc-transient.php
@@ -103,7 +103,14 @@ class TLC_Transient {
 		// We set the timeout as part of the transient data.
 		// The actual transient has a far-future TTL. This allows for soft expiration.
 		$expiration           = ( $this->expiration > 0 ) ? time() + $this->expiration : 0;
-		$transient_expiration = ( $this->expiration > 0 ) ? apply_filters( 'tlc_transient_ttl', 2592000 ) : 0; // 2592000 = 60*60*24*30 ~= one month for compatiblity with memcache
+		/**
+		 * Filter the default TTL used for transients. By default, this is set to one month for compatibility with Memcache.
+		 *
+		 * @param int $default_ttl TTL (in seconds) to use for transients.
+		 */
+		$default_ttl = apply_filters( 'tlc_transient_ttl', MONTH_IN_SECONDS );
+
+		$transient_expiration = ( $this->expiration > 0 ) ? $default_ttl : 0;
 		set_transient( 'tlc__' . $this->key, array( $expiration, $data ), $transient_expiration );
 		return $this;
 	}


### PR DESCRIPTION
Changed the far future TTL for the persisent transient to 30 days for compatibility with memcache based object caches
