### PR TITLE
Create a backdoor to force a cache refresh

### DIFF
--- a/class-tlc-transient.php
+++ b/class-tlc-transient.php
@@ -39,9 +39,12 @@ class TLC_Transient {
 	}
 
 	private function raw_get() {
-		if ( ! isset( $_GET['delete-trans'] ) || ! $_GET['delete-trans'] ) {
-			return get_transient( 'tlc__' . $this->key );
+		// Cache backdoor
+		if ( isset( $_REQUEST['delete-trans'] ) && $_REQUEST['delete-trans'] ) {
+			return false;
 		}
+
+		return get_transient( 'tlc__' . $this->key );
 	}
 
 	private function schedule_background_fetch() {

--- a/class-tlc-transient.php
+++ b/class-tlc-transient.php
@@ -39,7 +39,9 @@ class TLC_Transient {
 	}
 
 	private function raw_get() {
-		return get_transient( 'tlc__' . $this->key );
+		if ( ! isset( $_GET['delete-trans'] ) || ! $_GET['delete-trans'] ) {
+			return get_transient( 'tlc__' . $this->key );
+		}
 	}
 
 	private function schedule_background_fetch() {


### PR DESCRIPTION
This is an often-needed feature for clients. It also allows you to set your cache times much higher knowing that you could reset them if needed.
